### PR TITLE
Fix rules to create consistent deb file

### DIFF
--- a/debian/patches/make_install.patch
+++ b/debian/patches/make_install.patch
@@ -1,0 +1,25 @@
+--- nixnote2-master.orig/NixNote2.pro	2016-02-03 17:37:47.000000000 +0300
++++ nixnote2-master/NixNote2.pro	2016-02-05 16:42:30.179662437 +0300
+@@ -32,7 +32,7 @@ CONFIG(debug, debug|release) {
+         MOC_DIR = build/debug
+ }
+ 
+-CONFIG += debug_and_release
++CONFIG += debug_and_release copy_dir_files
+ 
+ TRANSLATIONS = \
+     translations/nixnote2_cs_CZ.ts \
+@@ -434,3 +434,13 @@ HEADERS  += nixnote.h \
+ 
+ QMAKE_CXXFLAGS +=-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security
+ QMAKE_LFLAGS += -Wl,-Bsymbolic-functions -Wl,-z,relro
++
++RESOURCE_FILES = certs help images qss translations java
++
++target.path = $$[QT_INSTALL_PREFIX]/bin/
++resources.files += $$RESOURCE_FILES
++resources.path = $$[QT_INSTALL_PREFIX]/share/nixnote2/
++applications.files = nixnote2.desktop
++applications.path = $$[QT_INSTALL_PREFIX]/share/applications/
++INSTALLS += target resources applications
++

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+make_install.patch

--- a/debian/rules
+++ b/debian/rules
@@ -21,12 +21,16 @@ include /usr/share/dpkg/default.mk
 %:
 	dh $@ 
 
-# debmake generated override targets
-# This is example for Cmake (See http://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- \
-#	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+override_dh_auto_build:
+	lupdate -pro NixNote2.pro -no-obsolete
+	lrelease NixNote2.pro
+	dh_auto_build
+	strip --strip-all nixnote2
 
-
-
-
+override_dh_auto_install:
+	dh_auto_install
+	mkdir debian/nixnote2/usr/share/nixnote2/spell
+	mkdir -p debian/nixnote2/usr/share/man/man1
+	cp man/nixnote2.1 debian/nixnote2/usr/share/man/man1/nixnote2.1
+	gzip -9 debian/nixnote2/usr/share/man/man1/nixnote2.1
+#	sed -i "s/__VERSION__/2.0-beta-4-0+git$(date +%Y%m%d)/" debian/nixnote2/usr/share/nixnote2/help/about.html


### PR DESCRIPTION
Nixnote2-daily create empty deb file. This patch fix it
